### PR TITLE
Fixed typo, _mode was being assigned to itself, not incoming argument.

### DIFF
--- a/stream/Gateway.cpp
+++ b/stream/Gateway.cpp
@@ -44,7 +44,7 @@ public:
 
     void setMode(const std::string &mode)
     {
-        _mode = _mode;
+        _mode = mode;
         _forwardMode = false;
         _backupMode = false;
         _dropMode = false;


### PR DESCRIPTION
Found this when building with clang