### PR TITLE
Added optional dependency on XSIMD, applies SIMD optimization to Clamp if found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,14 @@ if (NOT JSON_HPP_INCLUDE_DIR)
 endif (NOT JSON_HPP_INCLUDE_DIR)
 
 ########################################################################
+# xsimd
+########################################################################
+find_package(xsimd)
+if(xsimd_FOUND)
+    add_definitions(-DPOTHOS_XSIMD)
+endif()
+
+########################################################################
 # Build subdirectories
 ########################################################################
 add_subdirectory(file)

--- a/stream/CMakeLists.txt
+++ b/stream/CMakeLists.txt
@@ -10,6 +10,12 @@ endif()
 ########################################################################
 # Stream blocks module
 ########################################################################
+set(libraries "")
+
+if(xsimd_FOUND)
+    list(APPEND libraries xsimd)
+endif()
+
 include_directories(${JSON_HPP_INCLUDE_DIR})
 POTHOS_MODULE_UTIL(
     TARGET StreamBlocks
@@ -39,6 +45,11 @@ POTHOS_MODULE_UTIL(
         IsX.cpp
         TestIsX.cpp
         Mute.cpp
+    LIBRARIES ${libraries}
     DESTINATION blocks
     ENABLE_DOCS
 )
+
+if(xsimd_FOUND)
+    set_target_properties(StreamBlocks PROPERTIES COMPILE_FLAGS -march=native)
+endif()


### PR DESCRIPTION
[XSIMD](https://github.com/xtensor-stack/xsimd) is an MIT-licensed C++ SIMD library used as the underbelly of [XTensor](https://github.com/xtensor-stack/xtensor). This changelist adds a CMake check for XSIMD, and if detected, uses a SIMD implementation to speed up the Clamp block. A simple ``Noise Source -> Clamp -> Rate Monitor`` topology shows a 50-60% efficiency improvement for all types.

Obviously, the Clamp block is simply a demonstration. I've tested these optimizations on multiple PothosComms blocks and saw similar (if not better) improvements. This can also be applied to PothosCore's type conversions.

I tried out a few SIMD libraries, and this was the easiest to work with while providing decent functionality. A notable limitation is that unlike VOLK or [SIMDPP](http://p12tic.github.io/libsimdpp/v2.2-dev/libsimdpp/w/index.html), there is no dynamic dispatch, so only a single instruction set is compiled, making packaging non-ideal.

Note that this is a mostly-implemented, but incomplete, proposal. I've only tested this with Linux GCC, so I haven't added logic to set the appropriate MSVC compiler flags.