### PR TITLE
stream: refactored Clamp,MinMax,IsX to get implementation functions via getter functions

### DIFF
--- a/stream/IsX.cpp
+++ b/stream/IsX.cpp
@@ -8,36 +8,70 @@
 #include <cstdint>
 
 //
-// Wrappers that return the stream's output type
+// Implementation getters to be called on class construction
 //
 
-#define IS_X_ARRAY_FCN(NAME,FUNC) \
-    template <typename T> \
-    static void NAME(const T* in, std::int8_t* out, size_t num) \
-    { \
-        for(size_t i = 0; i < num; ++i) \
-        { \
-            out[i] = FUNC(in[i]) ? 1 : 0; \
-        } \
-    }
+template <typename T>
+using IsXFcn = void(*)(const T*, std::int8_t*, size_t);
 
-IS_X_ARRAY_FCN(IsFinite,   std::isfinite)
-IS_X_ARRAY_FCN(IsInf,      std::isinf)
-IS_X_ARRAY_FCN(IsNaN,      std::isnan)
-IS_X_ARRAY_FCN(IsNormal,   std::isnormal)
-IS_X_ARRAY_FCN(IsNegative, std::signbit)
+template <typename T>
+static inline IsXFcn<T> getIsFinite()
+{
+    return [](const T* in, std::int8_t* out, size_t num)
+    {
+        for (size_t i = 0; i < num; ++i) out[i] = std::isfinite(in[i]) ? 1 : 0;
+    };
+}
+
+template <typename T>
+static inline IsXFcn<T> getIsInf()
+{
+    return [](const T* in, std::int8_t* out, size_t num)
+    {
+        for (size_t i = 0; i < num; ++i) out[i] = std::isinf(in[i]) ? 1 : 0;
+    };
+}
+
+template <typename T>
+static inline IsXFcn<T> getIsNaN()
+{
+    return [](const T* in, std::int8_t* out, size_t num)
+    {
+        for (size_t i = 0; i < num; ++i) out[i] = std::isnan(in[i]) ? 1 : 0;
+    };
+}
+
+template <typename T>
+static inline IsXFcn<T> getIsNormal()
+{
+    return [](const T* in, std::int8_t* out, size_t num)
+    {
+        for (size_t i = 0; i < num; ++i) out[i] = std::isnormal(in[i]) ? 1 : 0;
+    };
+}
+
+template <typename T>
+static inline IsXFcn<T> getIsNegative()
+{
+    return [](const T* in, std::int8_t* out, size_t num)
+    {
+        for (size_t i = 0; i < num; ++i) out[i] = std::signbit(in[i]) ? 1 : 0;
+    };
+}
 
 //
 // Block implementation
 //
 
-template <typename T, void (*Fcn)(const T*, std::int8_t*, size_t)>
+template <typename T>
 class IsX: public Pothos::Block
 {
     public:
-        using Class = IsX<T,Fcn>;
+        using Class = IsX<T>;
 
-        IsX(size_t dimension): Pothos::Block()
+        IsX(size_t dimension, IsXFcn<T> fcn):
+            Pothos::Block(),
+            _fcn(fcn)
         {
             this->setupInput(0, Pothos::DType(typeid(T), dimension));
             this->setupOutput(0, Pothos::DType("int8", dimension));
@@ -56,11 +90,14 @@ class IsX: public Pothos::Block
 
             const T* inBuff = input->buffer();
             std::int8_t* outBuff = output->buffer();
-            Fcn(inBuff, outBuff, elems);
+            _fcn(inBuff, outBuff, elems);
 
             input->consume(elems);
             output->produce(elems);
         }
+
+    private:
+        IsXFcn<T> _fcn;
 };
 
 //
@@ -71,9 +108,9 @@ class IsX: public Pothos::Block
     static Pothos::Block* make ## func (const Pothos::DType& dtype) \
     { \
         if(Pothos::DType::fromDType(dtype, 1) == Pothos::DType(typeid(float))) \
-            return new IsX<float, func<float>>(dtype.dimension()); \
+            return new IsX<float>(dtype.dimension(), get ## func ## <float>()); \
         if(Pothos::DType::fromDType(dtype, 1) == Pothos::DType(typeid(double))) \
-            return new IsX<double, func<double>>(dtype.dimension()); \
+            return new IsX<double>(dtype.dimension(), get ## func ## <double>()); \
  \
         throw Pothos::InvalidArgumentException( \
                   std::string(__FUNCTION__)+": invalid type", \


### PR DESCRIPTION
Given that the WIP SIMD functions will need to be queried via a dynamic dispatch function, this refactor makes it easier to use one or the other based on build support or if the type itself has a SIMD implementation. This commit shouldn't change anything functionally, and as the getters are called on construction, there's no meaningful overhead.