### PR TITLE
Added optional SIMD implementation for /blocks/clamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,17 @@ if (NOT JSON_HPP_INCLUDE_DIR)
 endif (NOT JSON_HPP_INCLUDE_DIR)
 
 ########################################################################
+# SIMD dynamic dispatch, if supported by this Pothos build
+########################################################################
+include(PothosConfigSIMD OPTIONAL RESULT_VARIABLE SIMD_SUPPORTED)
+if(SIMD_SUPPORTED)
+    find_package(xsimd)
+    if(xsimd_FOUND)
+        add_definitions(-DPOTHOS_XSIMD)
+    endif()
+endif()
+
+########################################################################
 # Build subdirectories
 ########################################################################
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/stream/CMakeLists.txt
+++ b/stream/CMakeLists.txt
@@ -10,39 +10,62 @@ endif()
 ########################################################################
 # Stream blocks module
 ########################################################################
-include_directories(${JSON_HPP_INCLUDE_DIR})
+set(sources
+    Converter.cpp
+    TestConverter.cpp
+    Copier.cpp
+    Delay.cpp
+    TestDelay.cpp
+    DynamicRouter.cpp
+    Pacer.cpp
+    Relabeler.cpp
+    LabelStripper.cpp
+    Gateway.cpp
+    TestGateway.cpp
+    Reinterpret.cpp
+    RateMonitor.cpp
+    MinMax.cpp
+    TestMinMax.cpp
+    Interleaver.cpp
+    TestInterleaver.cpp
+    Deinterleaver.cpp
+    Clamp.cpp
+    TestClamp.cpp
+    Repeat.cpp
+    TestRepeat.cpp
+    IsX.cpp
+    TestIsX.cpp
+    Mute.cpp
+    Round.cpp
+    TestRoundBlocks.cpp
+    Replace.cpp
+    TestReplace.cpp)
+set(libraries "")
+
+if(xsimd_FOUND)
+    set(SIMDInputs
+        SIMD/Clamp.cpp)
+
+    PothosGenerateSIMDSources(
+        SIMDSources
+        SIMD/StreamBlocks.json
+        ${SIMDInputs})
+
+    list(APPEND sources ${SIMDSources})
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+    list(APPEND libraries xsimd)
+endif()
+
+include_directories(
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${JSON_HPP_INCLUDE_DIR})
 POTHOS_MODULE_UTIL(
     TARGET StreamBlocks
-    SOURCES
-        Converter.cpp
-        TestConverter.cpp
-        Copier.cpp
-        Delay.cpp
-        TestDelay.cpp
-        DynamicRouter.cpp
-        Pacer.cpp
-        Relabeler.cpp
-        LabelStripper.cpp
-        Gateway.cpp
-        TestGateway.cpp
-        Reinterpret.cpp
-        RateMonitor.cpp
-        MinMax.cpp
-        TestMinMax.cpp
-        Interleaver.cpp
-        TestInterleaver.cpp
-        Deinterleaver.cpp
-        Clamp.cpp
-        TestClamp.cpp
-        Repeat.cpp
-        TestRepeat.cpp
-        IsX.cpp
-        TestIsX.cpp
-        Mute.cpp
-        Round.cpp
-        TestRoundBlocks.cpp
-        Replace.cpp
-        TestReplace.cpp
+    SOURCES ${sources}
+    LIBRARIES ${libraries}
     DESTINATION blocks
     ENABLE_DOCS
 )
+if(xsimd_FOUND)
+    add_dependencies(StreamBlocks StreamBlocks_SIMDDispatcher)
+endif()

--- a/stream/SIMD/Clamp.cpp
+++ b/stream/SIMD/Clamp.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 Nicholas Corgan
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <xsimd/xsimd.hpp>
+
+#include <algorithm>
+
+#if !defined POTHOS_SIMD_NAMESPACE
+#error Must define POTHOS_SIMD_NAMESPACE to build this file
+#endif
+
+namespace PothosBlocksSIMD { namespace POTHOS_SIMD_NAMESPACE {
+
+template <typename T>
+void clamp(
+    const T* in,
+    T* out,
+    const T& lo,
+    const T& hi,
+    size_t len)
+{
+    static constexpr size_t simdSize = xsimd::simd_traits<T>::size;
+    const auto numSIMDFrames = len / simdSize;
+
+    auto loReg = xsimd::set_simd(lo);
+    auto hiReg = xsimd::set_simd(hi);
+
+    const T* inPtr = in;
+    T* outPtr = out;
+
+    for(size_t frameIndex = 0; frameIndex < numSIMDFrames; ++frameIndex)
+    {
+        auto inReg = xsimd::load_unaligned(inPtr);
+        auto outReg = xsimd::clip(inReg, loReg, hiReg);
+        outReg.store_unaligned(outPtr);
+
+        inPtr += simdSize;
+        outPtr += simdSize;
+    }
+
+    // Perform remaining operations manually.
+    for(size_t elem = (simdSize * numSIMDFrames); elem < len; ++elem)
+    {
+#if __cplusplus >= 201703L
+        out[elem] = std::clamp(in[elem], lo, hi);
+#else
+        // See: https://en.cppreference.com/w/cpp/algorithm/clamp
+        out[elem] = (in[elem] < lo) ? lo : (hi < in[elem]) ? hi : in[elem];
+#endif
+    }
+}
+
+#define CLAMP(T) template void clamp<T>(const T*, T*, const T&, const T&, size_t);
+CLAMP(std::int8_t)
+CLAMP(std::int16_t)
+CLAMP(std::int32_t)
+CLAMP(std::int64_t)
+CLAMP(std::uint8_t)
+CLAMP(std::uint16_t)
+// No uint32_t implementation due to SIMD limitation
+CLAMP(std::uint64_t)
+CLAMP(float)
+CLAMP(double)
+
+}}

--- a/stream/SIMD/StreamBlocks.json
+++ b/stream/SIMD/StreamBlocks.json
@@ -1,0 +1,12 @@
+{
+    "namespace": "PothosBlocksSIMD",
+    "functions":
+    [
+        {
+            "name": "clamp",
+            "returnType": "void",
+            "paramTypes": ["T"],
+            "params": ["const T*", "T*", "const T&", "const T&", "size_t"]
+        }
+    ]
+}


### PR DESCRIPTION
* Will automatically compile if supported by Pothos installation and XSIMD found
* Added testing function to expand test data to make sure SIMD is tested

See: https://github.com/pothosware/PothosCore/pull/215